### PR TITLE
docs: fix simple typo, registy -> registry

### DIFF
--- a/client/iocItems/RegistryItem.py
+++ b/client/iocItems/RegistryItem.py
@@ -39,7 +39,7 @@ def path(searchString,cacheItems=[],cache=False):
     """
     hits=False   
     if PLATFORM!='win':
-        #no registy 
+        #no registry 
         hits=False
     
     else:


### PR DESCRIPTION
There is a small typo in client/iocItems/RegistryItem.py.

Should read `registry` rather than `registy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md